### PR TITLE
Ensure responsive layout supports Pacman theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,42 +6,135 @@
 <title>Hybrid Trainer — Clean v11</title>
 <meta name="theme-color" content="#0b0b0c" />
 <style>
-  :root { --bg:#0b0b0c; --card:#141416; --muted:#9aa0a6; --text:#e7e9ea; --accent:#1db954; --warn:#f59e0b; --danger:#ef4444; --line:#24262a; }
+  :root {
+    --bg:#0b0b0c;
+    --card:#141416;
+    --muted:#9aa0a6;
+    --text:#e7e9ea;
+    --accent:#1db954;
+    --warn:#f59e0b;
+    --danger:#ef4444;
+    --line:#24262a;
+    --btn-bg:#1f2937;
+    --btn-text:#ffffff;
+    --btn-hover:#2a3648;
+    --btn-bad-bg:#2a1b1b;
+    --btn-bad-text:#ffffff;
+    --btn-bad-hover:#3a2222;
+    --btn-green-bg:#176b3d;
+    --btn-green-text:#ffffff;
+    --btn-green-hover:#1b7d47;
+    --pill-bg:#1f2937;
+    --pill-text:#d1fae5;
+    --pill-ok-bg:rgba(16,185,129,.15);
+    --pill-ok-text:#34d399;
+    --pill-warn-bg:rgba(245,158,11,.15);
+    --pill-warn-text:#f59e0b;
+    --input-bg:#1f2227;
+    --input-border:#2a2d33;
+    --input-text:#e7e9ea;
+    --table-head-bg:#1a1d22;
+    --table-border:#2b2e35;
+    --tag-bg:#0b1b30;
+    --tag-border:#173152;
+    --tag-text:#93c5fd;
+    --toast-bg:#1f2937;
+    --toast-border:#2a2d33;
+    --toast-text:#e7e9ea;
+  }
   *{box-sizing:border-box}
   body{margin:0;background:var(--bg);color:var(--text);font:14px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
-  .wrap{max-width:1120px;margin:24px auto;padding:0 16px}
+  body[data-theme="pacman"],body.theme-pacman{
+    --bg:#040218;
+    --card:#0c1032;
+    --muted:#9ba6ff;
+    --text:#fffbd1;
+    --accent:#ffd800;
+    --warn:#ffb347;
+    --danger:#ff4d6d;
+    --line:#1f2359;
+    --btn-bg:#1621a6;
+    --btn-text:#ffe066;
+    --btn-hover:#1e2ed6;
+    --btn-bad-bg:#4a144f;
+    --btn-bad-text:#ffe4f1;
+    --btn-bad-hover:#5f1b67;
+    --btn-green-bg:#1f8f42;
+    --btn-green-text:#fffbd1;
+    --btn-green-hover:#27a24d;
+    --pill-bg:rgba(22,33,166,.25);
+    --pill-text:#ffe066;
+    --pill-ok-bg:rgba(255,216,0,.3);
+    --pill-ok-text:#fffbd1;
+    --pill-warn-bg:rgba(255,149,0,.25);
+    --pill-warn-text:#ffd199;
+    --input-bg:#12183f;
+    --input-border:#232b6b;
+    --input-text:#fffbd1;
+    --table-head-bg:#12183f;
+    --table-border:#232b6b;
+    --tag-bg:#1621a6;
+    --tag-border:#2732c2;
+    --tag-text:#ffe066;
+    --toast-bg:#12183f;
+    --toast-border:#232b6b;
+    --toast-text:#fffbd1;
+  }
+  .wrap{width:min(100%,1120px);margin:24px auto;padding:0 32px}
   h1{font-size:24px;margin:0 0 6px}
   h2{font-size:18px;margin:0 0 8px}
   .row{display:grid;grid-template-columns:1fr 1fr;gap:16px}
-  @media (max-width:900px){.row{grid-template-columns:1fr}}
+  @media (max-width:960px){.row{grid-template-columns:1fr}}
   .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:14px}
   .muted{color:var(--muted)} .small{font-size:12px}
-  .btn{background:#1f2937;color:#fff;border:none;border-radius:12px;padding:8px 12px;cursor:pointer}
-  .btn:hover{background:#2a3648}
-  .btn.bad{background:#2a1b1b}.btn.bad:hover{background:#3a2222}
-  .btn.green{background:#176b3d}.btn.green:hover{background:#1b7d47}
-  .pill{display:inline-block;background:#1f2937;color:#d1fae5;border-radius:999px;padding:4px 8px;font-size:12px}
-  .pill.ok{background:rgba(16,185,129,.15);color:#34d399}
-  .pill.warn{background:rgba(245,158,11,.15);color:#f59e0b}
+  .btn{background:var(--btn-bg);color:var(--btn-text);border:none;border-radius:12px;padding:8px 12px;cursor:pointer;transition:background .15s ease,color .15s ease}
+  .btn:hover{background:var(--btn-hover)}
+  .btn.bad{background:var(--btn-bad-bg);color:var(--btn-bad-text)}.btn.bad:hover{background:var(--btn-bad-hover)}
+  .btn.green{background:var(--btn-green-bg);color:var(--btn-green-text)}.btn.green:hover{background:var(--btn-green-hover)}
+  .pill{display:inline-block;background:var(--pill-bg);color:var(--pill-text);border-radius:999px;padding:4px 8px;font-size:12px}
+  .pill.ok{background:var(--pill-ok-bg);color:var(--pill-ok-text)}
+  .pill.warn{background:var(--pill-warn-bg);color:var(--pill-warn-text)}
   .grid{display:grid;gap:8px}
   .g2{grid-template-columns:1fr 1fr}.g3{grid-template-columns:repeat(3,1fr)}.g4{grid-template-columns:repeat(4,1fr)}
-  input[type=number],input[type=text],select{width:100%;background:#1f2227;border:1px solid #2a2d33;color:#e7e9ea;border-radius:10px;padding:8px}
+  input[type=number],input[type=text],select{width:100%;background:var(--input-bg);border:1px solid var(--input-border);color:var(--input-text);border-radius:10px;padding:8px}
   input[type=range]{width:100%}
-  .flex{display:flex;gap:8px;align-items:center}
+  .flex{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+  .toolbar{gap:10px}
   .space{justify-content:space-between}
-  .list{max-height:180px;overflow:auto;border-top:1px solid var(--line);margin-top:8px;padding-top:8px}
+  .list{max-height:180px;overflow:auto;border-top:1px solid var(--line);margin-top:8px;padding-top:8px;-webkit-overflow-scrolling:touch}
   .line{height:1px;background:var(--line);margin:10px 0}
   label.small{display:flex;flex-direction:column;gap:4px}
-  .toast{position:fixed;left:50%;bottom:16px;transform:translateX(-50%);background:#1f2937;color:#e7e9ea;border:1px solid #2a2d33;border-radius:12px;padding:8px 12px;opacity:0;pointer-events:none;transition:opacity .2s;z-index:9999}
+  .toast{position:fixed;left:50%;bottom:16px;transform:translateX(-50%);background:var(--toast-bg);color:var(--toast-text);border:1px solid var(--toast-border);border-radius:12px;padding:8px 12px;opacity:0;pointer-events:none;transition:opacity .2s;z-index:9999}
   .toast.show{opacity:1}
   table{width:100%;border-collapse:collapse}
-  th,td{border:1px solid #2b2e35;padding:6px 8px;text-align:left}
-  th{background:#1a1d22;font-weight:600}
+  th,td{border:1px solid var(--table-border);padding:6px 8px;text-align:left}
+  th{background:var(--table-head-bg);font-weight:600}
   td input{width:100%}
-  .tag{font-size:11px;color:#93c5fd;background:#0b1b30;border:1px solid #173152;border-radius:999px;padding:2px 6px}
+  .tag{font-size:11px;color:var(--tag-text);background:var(--tag-bg);border:1px solid var(--tag-border);border-radius:999px;padding:2px 6px}
   .qa-item{display:flex;gap:8px;align-items:flex-start}
   .qa-item .pill{flex-shrink:0;margin-top:2px}
   .qa-empty{color:var(--muted)}
+  @media (max-width:720px){
+    .space.flex{flex-direction:column;align-items:flex-start;gap:16px}
+    .space.flex > *{width:100%}
+  }
+  @media (max-width:640px){
+    .toolbar{flex-direction:column;align-items:stretch;justify-content:flex-start;width:100%}
+    .toolbar > *{width:100%}
+    .card{padding:12px}
+    h1{font-size:22px}
+    h2{font-size:16px}
+    table{font-size:12px;min-width:520px;white-space:nowrap}
+    th,td{padding:6px}
+    .list{max-height:240px;font-size:13px}
+  }
+  @media (max-width:600px){
+    .wrap{padding:0 20px}
+  }
+  @media (max-width:480px){
+    h1{font-size:20px}
+    .card{padding:10px}
+  }
 </style>
 </head>
 <body>
@@ -51,7 +144,7 @@
         <h1>Hybrid Trainer — Clean v11</h1>
         <div class="muted small">Single HTML. Local save + export/import. No service worker.</div>
       </div>
-      <div class="flex">
+      <div class="flex toolbar">
         <button id="exportBtn" class="btn">Export</button>
         <label class="btn"><input id="importFile" type="file" accept="application/json" style="display:none">Import</label>
         <button id="resetWeek" class="btn">Reset Week</button>
@@ -206,7 +299,7 @@
       <div id="accWrap">
         <div class="space flex">
           <h3 style="margin:0">Accessories</h3>
-          <div class="flex" style="flex-wrap:wrap;gap:6px 8px">
+          <div class="flex toolbar" style="flex-wrap:wrap;gap:6px 8px">
             <select id="newAccTarget">
               <option>Back</option><option>Chest</option><option>Delts</option><option>Arms</option>
               <option>Quads</option><option>Posterior</option><option>Calves</option><option>Tib</option>
@@ -459,7 +552,7 @@ function buildWodUI(container, preset){
       <input placeholder="Movement (e.g., KB Swing)" value="${nameV}">
       <input placeholder="Reps/Time (e.g., 15 or 30s)" value="${repsV}">
       <input placeholder="Load (e.g., 24kg or light)" value="${loadV}">
-      <div class="flex" style="justify-content:space-between">
+      <div class="flex toolbar" style="justify-content:space-between">
         <label class="small" style="flex-direction:row;gap:8px;align-items:center"><input class="w-bw" type="checkbox" ${bw?"checked":""}> BW</label>
         <button class="btn bad w-del">X</button>
       </div>`;


### PR DESCRIPTION
## Summary
- update the wrap container and grid breakpoint so the layout uses a fluid width and collapses to a single column earlier
- add responsive rules to stack flex toolbars, adjust card spacing, and keep tables/lists readable on small screens
- expose component colors through CSS variables and add Pacman theme overrides so the new palette works with the responsive layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d988e4e1a48328910459fd762db52f