### PR TITLE
Improve mobile experience and typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,10 @@
   <meta name="theme-color" content="#030212" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;600&family=Press+Start+2P&display=swap"
+    rel="stylesheet"
+  />
   <style>
     :root {
       --bg:#030212;
@@ -33,25 +36,29 @@
       background-size:22px 22px;
       background-position:0 0,11px 11px;
       color:var(--text);
-      font:12px/1.5 "Press Start 2P","Courier New",monospace;
-      letter-spacing:0.4px;
+      font-family:"Chakra Petch","Press Start 2P","Courier New",monospace;
+      font-size:15px;
+      line-height:1.7;
+      letter-spacing:0.2px;
+      text-rendering:optimizeLegibility;
+      -webkit-font-smoothing:antialiased;
     }
-    .wrap{max-width:1120px;margin:24px auto;padding:0 16px}
-    h1{font-size:24px;margin:0 0 6px;letter-spacing:2px;text-shadow:0 0 12px var(--glow)}
+    .wrap{max-width:1120px;margin:24px auto;padding:0 20px}
+    h1{font-family:"Press Start 2P","Chakra Petch","Courier New",monospace;font-size:24px;margin:0 0 8px;letter-spacing:1.5px;text-shadow:0 0 12px var(--glow)}
     h1::before{content:"◥";color:var(--accent);margin-right:10px;text-shadow:0 0 8px var(--accent)}
-    h2{font-size:16px;margin:0 0 8px;letter-spacing:1px;text-transform:uppercase;text-shadow:0 0 10px rgba(45,251,255,.6);display:flex;align-items:center;gap:8px}
+    h2{font-family:"Press Start 2P","Chakra Petch","Courier New",monospace;font-size:16px;margin:0 0 10px;letter-spacing:1px;text-transform:uppercase;text-shadow:0 0 10px rgba(45,251,255,.6);display:flex;align-items:center;gap:8px}
     h2::before{content:"◢";color:var(--accent);text-shadow:0 0 10px var(--accent);}
-  .row{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+  .row{display:grid;grid-template-columns:1fr 1fr;gap:18px}
   @media (max-width:900px){.row{grid-template-columns:1fr}}
     .card{
       background:linear-gradient(180deg,var(--card) 0%,var(--card-alt) 100%);
       border:2px solid var(--line);
-      padding:16px;
+      padding:20px 18px;
       box-shadow:0 0 0 2px #000 inset,4px 4px 0 0 rgba(0,0,0,.75);
       transition:box-shadow .15s ease,transform .15s ease;
     }
     .card:hover{box-shadow:0 0 0 2px var(--accent) inset,6px 6px 0 0 rgba(0,0,0,.85);transform:translate(-2px,-2px)}
-  .muted{color:var(--muted)} .small{font-size:12px}
+  .muted{color:var(--muted)} .small{font-size:0.9rem}
     .btn{
       background:linear-gradient(180deg,var(--card-alt),#03102a);
       color:var(--accent);
@@ -60,7 +67,8 @@
       cursor:pointer;
       box-shadow:0 0 0 2px #000 inset,4px 4px 0 0 rgba(0,0,0,.85);
       text-transform:uppercase;
-      letter-spacing:1px;
+      letter-spacing:0.6px;
+      font-size:0.95rem;
       display:inline-flex;
       align-items:center;
       gap:8px;
@@ -107,8 +115,8 @@
       color:var(--accent);
       border:2px solid var(--accent-dark);
       padding:6px 12px;
-      font-size:10px;
-      letter-spacing:0.5px;
+      font-size:0.8rem;
+      letter-spacing:0.4px;
       box-shadow:2px 2px 0 0 rgba(0,0,0,.85);
       position:relative;
       text-transform:uppercase;
@@ -120,7 +128,7 @@
     .pill.ok::before{color:#00ffa2;text-shadow:0 0 6px #00ffa2}
     .pill.warn{border-color:var(--warn);color:var(--warn)}
     .pill.warn::before{color:var(--warn);text-shadow:0 0 6px var(--warn)}
-  .grid{display:grid;gap:8px}
+  .grid{display:grid;gap:12px}
   .g2{grid-template-columns:1fr 1fr}.g3{grid-template-columns:repeat(3,1fr)}.g4{grid-template-columns:repeat(4,1fr)}
     input[type=number],input[type=text],select{
       width:100%;
@@ -135,8 +143,6 @@
     }
     input[type=number]:focus,input[type=text]:focus,select:focus{outline:none;border-color:var(--accent);box-shadow:inset 0 0 0 2px #000,0 0 10px rgba(255,207,0,.6)}
     input[type=range]{width:100%;accent-color:var(--accent)}
-  .flex{display:flex;gap:8px;align-items:center}
-  .space{justify-content:space-between}
   .list{max-height:180px;overflow:auto;border-top:1px solid var(--line);margin-top:8px;padding-top:8px}
   .line{height:1px;background:var(--line);margin:10px 0}
   label.small{display:flex;flex-direction:column;gap:4px}
@@ -160,7 +166,7 @@
     th{background:var(--card-alt);font-weight:600;color:var(--accent);text-shadow:0 0 6px rgba(45,251,255,.6)}
   td input{width:100%}
     .tag{
-      font-size:10px;
+      font-size:0.8rem;
       color:var(--muted);
       background:linear-gradient(180deg,#041029,#020713);
       border:2px solid var(--line);
@@ -169,9 +175,26 @@
       text-transform:uppercase;
       box-shadow:2px 2px 0 0 rgba(0,0,0,.8);
     }
-  .qa-item{display:flex;gap:8px;align-items:flex-start}
+  .qa-item{display:flex;gap:10px;align-items:flex-start}
   .qa-item .pill{flex-shrink:0;margin-top:2px}
   .qa-empty{color:var(--muted)}
+  .flex{display:flex;gap:12px;align-items:center;flex-wrap:wrap}
+  .space{justify-content:space-between;gap:16px}
+  @media (max-width:720px){
+    body{font-size:16px;line-height:1.75;letter-spacing:0.1px}
+    .wrap{margin:16px auto;padding:0 14px}
+    .space{flex-direction:column;align-items:flex-start}
+    .space>.flex{width:100%;justify-content:stretch}
+    .space>.flex .btn{flex:1 1 30%;min-width:0;justify-content:center}
+    .row{grid-template-columns:1fr;gap:16px}
+    .g2,.g3,.g4{grid-template-columns:1fr}
+    .card{padding:18px 16px}
+    h1{font-size:20px;line-height:1.4}
+    h2{font-size:14px}
+    .btn{width:100%}
+    table{font-size:0.95rem}
+    th,td{padding:8px 10px}
+  }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- replace the pixelated default font with a Chakra Petch-based stack and enlarge base type for readability
- adjust buttons, pills, and spacing to keep UI legible while retaining the retro styling
- add mobile-focused flex and grid behaviors so action areas stack cleanly on small screens

## Testing
- Manual QA: Viewed index.html in a local browser

------
https://chatgpt.com/codex/tasks/task_e_68d9ee0d0c308328be0eee9d67a06081