### PR TITLE
Allow decimal endurance distances and add meters unit

### DIFF
--- a/index.html
+++ b/index.html
@@ -642,8 +642,7 @@
               >Distance<input
                 id="dist"
                 type="number"
-                inputmode="numeric"
-                pattern="[0-9]*"
+                inputmode="decimal"
                 min="0"
                 step="0.1"
                 placeholder="5"
@@ -652,6 +651,7 @@
               >Unit<select id="distUnit">
                 <option>mi</option>
                 <option>km</option>
+                <option>m</option>
               </select></label
             >
           </div>


### PR DESCRIPTION
## Summary
- allow entering endurance distances with decimal points by switching the distance input to decimal mode
- add meters as an available distance unit for endurance sessions

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e40cab375c8328ad5eb39dfc0bb488